### PR TITLE
fixed online report message

### DIFF
--- a/death_message_bot/main.py
+++ b/death_message_bot/main.py
@@ -24,7 +24,7 @@ def send_death_message(death_message):
 
 
 def online_players_command(update, context):
-  stream = os.popen(f'mcrcon -H 127.0.0.1 -p {os.getenv("MCRCON_PASS")} online')
+  stream = os.popen(f'mcrcon -c -H 127.0.0.1 -p {os.getenv("MCRCON_PASS")} online')
   out = stream.read()
   out = out.rstrip()
 


### PR DESCRIPTION
Fixed the message for when asking for online players on telegram. 

the problem was that mcrcon was giving extra characters that is used for coloring the console.
using the flag -c we can omit these characters.